### PR TITLE
Workaround to NSStringFromClass/NSClassFromString bug in iOS7

### DIFF
--- a/MOAspects/MOARuntime.h
+++ b/MOAspects/MOARuntime.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <objc/runtime.h>
 
 @interface MOARuntime : NSObject
 

--- a/MOAspects/MOAspects.m
+++ b/MOAspects/MOAspects.m
@@ -112,7 +112,7 @@ NSString * const MOAspectsPrefix = @"__moa_aspects_";
         if (![self copyMethodForClass:clazz atSelector:selector toSelector:aspectsSelector methodType:methodType]) {
             MOAspectsErrorLog(@"%@[%@ %@] failed copy method",
                               methodType == MOAspectsTargetMethodTypeClass ? @"+" : @"-",
-                              NSStringFromClass(clazz),
+                              [NSString stringWithCString:object_getClassName(clazz) encoding:NSUTF8StringEncoding],
                               NSStringFromSelector(aspectsSelector));
             return NO;
         }
@@ -181,7 +181,7 @@ NSString * const MOAspectsPrefix = @"__moa_aspects_";
     if ([NSStringFromSelector(selector) hasPrefix:MOAspectsPrefix]) {
         MOAspectsErrorLog(@"%@[%@ %@] can not hook \"__moa_aspects_\" prefix selector",
                           methodType == MOAspectsTargetMethodTypeClass ? @"+" : @"-",
-                          NSStringFromClass(clazz),
+                          [NSString stringWithCString:object_getClassName(clazz) encoding:NSUTF8StringEncoding],
                           NSStringFromSelector(selector));
         return NO;
     }
@@ -189,7 +189,7 @@ NSString * const MOAspectsPrefix = @"__moa_aspects_";
     if (![self hasMethodForClass:clazz selector:selector methodType:methodType]) {
         MOAspectsErrorLog(@"%@[%@ %@] unrecognized selector",
                           methodType == MOAspectsTargetMethodTypeClass ? @"+" : @"-",
-                          NSStringFromClass(clazz),
+                          [NSString stringWithCString:object_getClassName(clazz) encoding:NSUTF8StringEncoding],
                           NSStringFromSelector(selector));
         return NO;
     }

--- a/MOAspects/MOAspectsStore.m
+++ b/MOAspects/MOAspectsStore.m
@@ -43,7 +43,7 @@ NSString * const MOAspectsStoreKeyFormat = @"%@[%@ %@]";
 {
     return [NSString stringWithFormat:MOAspectsStoreKeyFormat,
             methodType == MOAspectsTargetMethodTypeClass ? @"+" : @"-",
-            NSStringFromClass(clazz),
+            [NSString stringWithCString:object_getClassName(clazz) encoding:NSUTF8StringEncoding],
             NSStringFromSelector(selector)];
 }
 

--- a/MOAspects/MOAspectsTarget.m
+++ b/MOAspects/MOAspectsTarget.m
@@ -71,19 +71,20 @@
 {
     NSValue *selectorValue = [NSValue valueWithPointer:selector];
     [self.beforeSelectors addObject:selectorValue];
-    self.selectorClassInfo[NSStringFromSelector(selector)] = NSStringFromClass(clazz);
+    self.selectorClassInfo[NSStringFromSelector(selector)] = [NSString stringWithCString:object_getClassName(clazz) encoding:NSUTF8StringEncoding];
 }
 
 - (void)addAfterSelector:(SEL)selector forClass:(Class)clazz
 {
     NSValue *selectorValue = [NSValue valueWithPointer:selector];
     [self.afterSelectors addObject:selectorValue];
-    self.selectorClassInfo[NSStringFromSelector(selector)] = NSStringFromClass(clazz);
+    self.selectorClassInfo[NSStringFromSelector(selector)] = [NSString stringWithCString:object_getClassName(clazz) encoding:NSUTF8StringEncoding];
 }
 
 - (Class)classForSelector:(SEL)selector
 {
-    return NSClassFromString(self.selectorClassInfo[NSStringFromSelector(selector)]);
+    NSString *className = self.selectorClassInfo[NSStringFromSelector(selector)];
+    return objc_getClass([className cStringUsingEncoding:NSUTF8StringEncoding]);
 }
 
 @end


### PR DESCRIPTION
Hooking Swift class/method from Objective-C is always failed in iOS7.

There are a bug in NSStringFromClass and NSClassFromString on iOS7.
See [this topics](https://github.com/hackiftekhar/IQKeyboardManager/issues/111) or [this article](http://aroundthedistance.hatenadiary.jp/entry/2015/01/30/164922) 

Then, all of NSStringFromClass must be replaced into object_getClassName and NSClassFromString must be into objc_getClass to support iOS7. Of course, these changes also work good in iOS8.

---

FYI:
objc_getClass(@"projectName.className") returns nil in iOS7.
You must pass a string like this: objc_getClass(@"_TtC11ProjectName9ClassName")
See [the post in stack overflow](http://stackoverflow.com/questions/24030814/swift-language-nsclassfromstring) in detail.
